### PR TITLE
Improvements to data_io

### DIFF
--- a/config/hadron_jet_RAA.yaml
+++ b/config/hadron_jet_RAA.yaml
@@ -34,6 +34,8 @@ analysis_base: &model_base
   parameterizations: ['exponential']
   sqrts_list: [200, 2760, 5020]
   centrality_range: [0,10]
+  # Can also be a list of centrality ranges. eg:
+  #centrality_range: [[0, 10], [30, 50]]
   recoil_scheme: 'negative_recominber'
   parameters:
     exponential:

--- a/config/hadron_jet_RAA.yaml
+++ b/config/hadron_jet_RAA.yaml
@@ -35,8 +35,8 @@ analysis_base: &model_base
   sqrts_list: [200, 2760, 5020]
   centrality_range: [0,10]
   recoil_scheme: 'negative_recominber'
-  parameters: 
-    exponential: 
+  parameters:
+    exponential:
       names: ['$\\alpha_S^{\\rm{fix}}$', '$Q_0$', '$c_1$', '$c_2$', '$c_3$', '$\\tau_0$']
       min: [0.1, 1, 0, 0, 0, 0]
       max: [0.5, 10, 10, 10, 100, 1.5]
@@ -59,6 +59,10 @@ analyses:
     <<: *model_base
     observable_list:
       - 'jet__pt_'
+    # Optionally, exclude some observables which would otherwise be selected.
+    # eg. only want mid rapidity observables, so exclude the rapidity dependent jet RAA
+    #observable_exclude_list:
+    #  - "pt_y_atlas"
     plot_panel_shapes: [[3,3], [3,3], [3,3]]
 
 #-------------------------------------------
@@ -74,7 +78,7 @@ linear_weights: []
 covariance_function: 'matern'                  # squared_exponential, power_exponential, matern
 matern_nu: 1.5
 variance: 1                                    # overall variance
-noise: None                                    
+noise: None
 
 # Validation
 # We want to support the following:

--- a/config/rehlers.yaml
+++ b/config/rehlers.yaml
@@ -4,7 +4,7 @@
 
 output_dir: 'output/20230227'
 
-initialize_observables: False
+initialize_observables: True
 fit_emulators: False
 run_mcmc: False
 plot: True
@@ -59,6 +59,9 @@ analyses:
     <<: *model_base
     observable_list:
       - 'jet__pt_'
+    observable_exclude_list:
+      # Exclude the ATLAS rapidity dependent, since we don't want to deal with it for now
+      - "pt_y_atlas"
     plot_panel_shapes: [[3,3], [3,3], [3,3]]
 
 #-------------------------------------------

--- a/config/rehlers.yaml
+++ b/config/rehlers.yaml
@@ -33,7 +33,8 @@ analysis_base: &model_base
   model_name: 'MATTER+LBT'
   parameterizations: ['exponential']
   sqrts_list: [200, 2760, 5020]
-  centrality_range: [0, 10]
+  #centrality_range: [[0, 10], [30, 50]]
+  centrality_range: [[0, 10]]
   recoil_scheme: 'negative_recominber'
   parameters:
     exponential:

--- a/config/rehlers.yaml
+++ b/config/rehlers.yaml
@@ -1,0 +1,101 @@
+# Configuration for STAT analysis
+#-------------------------------------------
+# General parameters
+
+output_dir: 'output/20230227'
+
+initialize_observables: False
+fit_emulators: False
+run_mcmc: False
+plot: True
+
+debug_level: 0
+
+#-------------------------------------------
+# The design points, predictions, and experimental data are located in tables produced by the aggregation machinery
+observable_table_dir: 'data/20230116/tables'
+
+# We make use of some info in the JETSCAPE-analysis config that was used to aggregate/plot observables
+observable_config_dir: '../JETSCAPE-analysis/config'
+
+#-------------------------------------------
+# Specify observables
+# We want to allow to configure the analysis to only use various subsets of observables
+#   (e.g. jet/hadron/substructure observables, sqrts, centrality, ...)
+# We will do this by looping over the specified models below:
+#   - We will loop through the parameterizations and run a separate analysis for each
+#   - We will start by using all observables in the table directory for that parameterization
+#   - We will then filter by the sqrts, centrality specified
+#   - Finally, we select any observables whose filename contains a string from observable_list
+
+# Set general share parameters
+analysis_base: &model_base
+  model_name: 'MATTER+LBT'
+  parameterizations: ['exponential']
+  sqrts_list: [200, 2760, 5020]
+  centrality_range: [0, 10]
+  recoil_scheme: 'negative_recominber'
+  parameters:
+    exponential:
+      names: ['$\\alpha_S^{\\rm{fix}}$', '$Q_0$', '$c_1$', '$c_2$', '$c_3$', '$\\tau_0$']
+      min: [0.1, 1, 0, 0, 0, 0]
+      max: [0.5, 10, 10, 10, 100, 1.5]
+    binomial:
+      names: ['$\\alpha_S^{\\rm{fix}}$', '$Q_0$', '$c_1$', '$c_2$', '$a$', '$b$', '$\\tau_0$']
+      min: [0.1, 1, 0, 0, -10, -10, 0]
+      max: [0.5, 10, 10, 10, 100, 100, 1.5]
+  alpha: 0.2
+  validation_indices: [200, 230] # For exp parameterization, these are the same for all sqrts (i.e. all points 200-229 inclusive)
+
+analyses:
+
+  analysis1:
+    <<: *model_base
+    observable_list:
+      - 'hadron__pt_'
+    plot_panel_shapes: [[3,3], [3,3]]
+
+  analysis2:
+    <<: *model_base
+    observable_list:
+      - 'jet__pt_'
+    plot_panel_shapes: [[3,3], [3,3], [3,3]]
+
+#-------------------------------------------
+# Emulator parameters
+force_retrain: True
+n_pc: 4
+n_restarts: 50
+
+mean_function: 'constant'                      # constant, linear
+constant: 0.
+linear_weights: []
+
+covariance_function: 'matern'                  # squared_exponential, power_exponential, matern
+matern_nu: 1.5
+variance: 1                                    # overall variance
+noise: None
+
+# Validation
+# We want to support the following:
+#  - k-fold cross-validation
+#  - validation dataset
+
+# Cross-validation
+cross_validation: True
+cross_validation_k: 5
+
+# TODO: Independent validation dataset
+independent_validation: False
+
+#-------------------------------------------
+# MCMC parameters
+n_walkers: 500
+n_burn_steps: 1000
+n_sampling_steps: 500
+
+n_logging_steps: 100
+
+#-------------------------------------------
+# Closure test parameters
+confidence: [0.9, 0.6]

--- a/src/bayesian_inference/data_IO.py
+++ b/src/bayesian_inference/data_IO.py
@@ -165,7 +165,7 @@ def write_dict_to_h5(results, output_dir, filename, verbose=True):
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    dicttoh5(results, os.path.join(output_dir, filename), overwrite_data=True)
+    dicttoh5(results, os.path.join(output_dir, filename), update_mode="modify")
 
     if verbose:
         logger.info('Done.')

--- a/src/bayesian_inference/data_IO.py
+++ b/src/bayesian_inference/data_IO.py
@@ -438,11 +438,20 @@ def _accept_observable(analysis_config, filename):
         return False
 
     # Check centrality
-    accepted_centrality = False
     centrality_min, centrality_max = centrality.split('-')
-    if int(centrality_min) >= analysis_config['centrality_range'][0]:
-        if int(centrality_max) <= analysis_config['centrality_range'][1]:
-            accepted_centrality = True
+    # Validation
+    # Provided a single centrality range - convert to a list of ranges
+    centrality_ranges = analysis_config['centrality_range']
+    if not isinstance(centrality_ranges[0], list):
+        centrality_ranges = [list(centrality_ranges)]
+
+    accepted_centrality = False
+    for (selected_cent_min, selected_cent_max) in centrality_ranges:
+        if int(centrality_min) >= selected_cent_min:
+            if int(centrality_max) <= selected_cent_max:
+                accepted_centrality = True
+                # Bail out - no need to keep looping if it's already accepted
+                break
     if not accepted_centrality:
         return False
 

--- a/src/bayesian_inference/data_IO.py
+++ b/src/bayesian_inference/data_IO.py
@@ -116,6 +116,8 @@ def initialize_observables_dict_from_tables(table_dir, analysis_config, paramete
                 with open(os.path.join(prediction_dir, filename_prediction_values)) as f:
                     for line in f.readlines():
                         if 'design_point' in line:
+                            # NOTE: 12 == len("design_point"), so this strips out the leading
+                            #       "design_point" text to extract the design point index
                             indices = set([int(s[12:]) for s in line.split('#')[1].split()])
                 training_indices_numpy = list(indices - set(validation_indices))
                 validation_indices_numpy = list(indices.intersection(set(validation_indices)))

--- a/src/bayesian_inference/data_IO.py
+++ b/src/bayesian_inference/data_IO.py
@@ -30,7 +30,7 @@ def initialize_observables_dict_from_tables(table_dir, analysis_config, paramete
     Initialize from .dat files into a dictionary of numpy arrays
       - We loop through all observables in the table directory for the given model and parameterization
       - We include only those observables:
-         - That have sqrts,centrality specified in the analysis_config
+         - That have sqrts, centrality specified in the analysis_config
          - Whose filename contains a string from analysis_config observable_list
       - We also separate out the design/predictions with indices in the validation set
 

--- a/src/bayesian_inference/data_IO.py
+++ b/src/bayesian_inference/data_IO.py
@@ -447,14 +447,21 @@ def _accept_observable(analysis_config, filename):
         return False
 
     # Check observable
-    found_observable = False
-    for observable_string in analysis_config['observable_list']:
-        if observable_string in filename:
-            found_observable = True
-    if not found_observable:
-        return False
+    # Select observables based on the input list, with the possibility of excluding some
+    # observables with additional selection strings (eg. remove one experiment from the
+    # observables for an exploratory analysis).
+    config_observable_list = analysis_config['observable_list']
+    config_observable_exclude_list = analysis_config.get("observable_exclude_list", [])
+    observable_in_include_list = any([observable_string in filename for observable_string in config_observable_list])
+    observable_in_exclude_list = any([exclude in filename for exclude in config_observable_exclude_list])
 
-    return True
+    found_observable = (observable_in_include_list and not observable_in_exclude_list)
+
+    # Helpful for cross checking when debugging
+    if observable_in_exclude_list:
+        logger.debug(f"Excluding observable '{filename}' due to exclude list. {found_observable=}")
+
+    return found_observable
 
 #---------------------------------------------------------------
 def _split_training_validation_indices(validation_indices, observable_table_dir, parameterization):

--- a/src/bayesian_inference/data_IO.py
+++ b/src/bayesian_inference/data_IO.py
@@ -15,7 +15,6 @@ authors: J.Mulligan, R.Ehlers
 
 import os
 import logging
-import sys
 from collections import defaultdict
 from operator import itemgetter
 import numpy as np
@@ -82,7 +81,8 @@ def initialize_observables_dict_from_tables(table_dir, analysis_config, paramete
             observables['Data'][observable_label] = data_entry
 
             if 0 in data_entry['y']:
-                sys.exit(f'{filename} has value=0')
+                msg = f'{filename} has value=0'
+                raise ValueError(msg)
 
     #----------------------
     # Read design points
@@ -133,12 +133,14 @@ def initialize_observables_dict_from_tables(table_dir, analysis_config, paramete
                 # Check that data and prediction have same observables with the same size
                 if observable_label not in observables['Data']:
                     data_keys = observables['Data'].keys()
-                    sys.exit(f'{observable_label} not found in observables[Data]: {data_keys}')
+                    msg = f'{observable_label} not found in observables[Data]: {data_keys}'
+                    raise ValueError(msg)
 
                 data_size = observables['Data'][observable_label]['y'].shape[0]
                 prediction_size = observables['Prediction'][observable_label]['y'].shape[0]
                 if data_size != prediction_size:
-                    sys.exit(f'({filename_prediction_values}) has different shape ({prediction_size}) than Data ({data_size}).')
+                    msg = f'({filename_prediction_values}) has different shape ({prediction_size}) than Data ({data_size}).'
+                    raise ValueError(msg)
 
     #----------------------
     # Construct covariance matrices

--- a/src/bayesian_inference/steer_analysis.py
+++ b/src/bayesian_inference/steer_analysis.py
@@ -9,7 +9,6 @@ Based in part on JETSCAPE/STAT code.
 import argparse
 import logging
 import os
-import sys
 import yaml
 
 from bayesian_inference import data_IO
@@ -160,8 +159,9 @@ if __name__ == '__main__':
 
     # If invalid configFile is given, exit
     if not os.path.exists(args.configFile):
-        logger.info(f'File {args.configFile} does not exist! Exiting!')
-        sys.exit(0)
+        msg = f'File {args.configFile} does not exist! Exiting!'
+        logger.info(msg)
+        raise ValueError(msg)
 
     analysis = SteerAnalysis(config_file=args.configFile)
     analysis.run_analysis()

--- a/src/bayesian_inference/steer_analysis.py
+++ b/src/bayesian_inference/steer_analysis.py
@@ -49,14 +49,17 @@ class SteerAnalysis(common_base.CommonBase):
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
 
+        # Data inputs
         self.observable_table_dir = config['observable_table_dir']
         self.observable_config_dir = config['observable_config_dir']
 
+        # Configure which functions to run
         self.initialize_observables = config['initialize_observables']
         self.fit_emulators = config['fit_emulators']
         self.run_mcmc = config['run_mcmc']
         self.plot = config['plot']
 
+        # Configuration of different analyses
         self.analyses = config['analyses']
 
     #---------------------------------------------------------------


### PR DESCRIPTION
Added (both are backwards compatible):
- Observable exclusion list to make selections more configurable
- Selection of non-continuous centrality ranges

Some QOL changes:
- Use exceptions instead of sys.exit
- Update deprecated silx API call (See docs [here](https://www.silx.org/doc/silx/latest/modules/io/dictdump.html#silx.io.dictdump.dicttoh5) . I think the change is consistent, but a double check would be good since I'm not 100% familiar with hdf5 + silx terminology)