### PR TITLE
Add observable_filter to general EmulationConfig

### DIFF
--- a/src/bayesian_inference/data_IO.py
+++ b/src/bayesian_inference/data_IO.py
@@ -613,6 +613,7 @@ def _accept_observable(analysis_config, filename):
     # Select observables based on the input list, with the possibility of excluding some
     # observables with additional selection strings (eg. remove one experiment from the
     # observables for an exploratory analysis).
+    # NOTE: This is equivalent to EmulationConfig.observable_filter
     accept_observable = False
     global_observable_exclude_list = analysis_config.get("global_observable_exclude_list", [])
     for emulation_group_settings in analysis_config["parameters"]["emulators"].values():

--- a/src/bayesian_inference/mcmc.py
+++ b/src/bayesian_inference/mcmc.py
@@ -59,23 +59,22 @@ def run_mcmc(config, closure_index=-1):
     )
     emulation_results = emulation_config.read_all_emulator_groups()
 
-    # FIXME: The experimental results are NOT in the same order as the emulator groups!
     # Load experimental data into arrays: experimental_results['y'/'y_err'] (n_features,)
     # In the case of a closure test, we use the pseudodata from the validation design point
-    experimental_results = data_IO.data_array_from_h5(config.output_dir, 'observables.h5', pseudodata_index=closure_index)
+    experimental_results = data_IO.data_array_from_h5(config.output_dir, 'observables.h5', pseudodata_index=closure_index, observable_filter=emulation_config.observable_filter)
 
     # TODO: By default the chain will be stored in memory as a numpy array
     #       If needed we can create a h5py dataset for compression/chunking
 
     # We can use multiprocessing in emcee to parallelize the independent walkers
-    with Pool() as pool:
+    with Pool(processes=1) as pool:
 
         # Construct sampler (we create a dummy daughter class from emcee.EnsembleSampler, to add some logging info)
         # Note: we pass the emulators and experimental data as args to the log_posterior function
         logger.info('Initializing sampler...')
         sampler = LoggingEnsembleSampler(config.n_walkers, ndim, _log_posterior,
                                         args=[min, max, emulation_config, emulation_results, experimental_results],
-                                        pool=pool)
+                                        )#pool=pool)
 
         # Generate random starting positions for each walker
         random_pos = np.random.uniform(min, max, (config.n_walkers, ndim))

--- a/src/bayesian_inference/mcmc.py
+++ b/src/bayesian_inference/mcmc.py
@@ -67,14 +67,14 @@ def run_mcmc(config, closure_index=-1):
     #       If needed we can create a h5py dataset for compression/chunking
 
     # We can use multiprocessing in emcee to parallelize the independent walkers
-    with Pool(processes=1) as pool:
+    with Pool() as pool:
 
         # Construct sampler (we create a dummy daughter class from emcee.EnsembleSampler, to add some logging info)
         # Note: we pass the emulators and experimental data as args to the log_posterior function
         logger.info('Initializing sampler...')
         sampler = LoggingEnsembleSampler(config.n_walkers, ndim, _log_posterior,
                                         args=[min, max, emulation_config, emulation_results, experimental_results],
-                                        )#pool=pool)
+                                        pool=pool)
 
         # Generate random starting positions for each walker
         random_pos = np.random.uniform(min, max, (config.n_walkers, ndim))

--- a/src/bayesian_inference/plot_mcmc.py
+++ b/src/bayesian_inference/plot_mcmc.py
@@ -362,9 +362,9 @@ def _plot_posterior_observables(chain, plot_dir, config, n_samples=200):
         config_file=config.config_file,
     )
     emulator_predictions = emulation.predict(posterior_samples, emulation_config=emulation_config)
-    # FIXME: The observable list doesn't match up in order with the emulator results
     emulator_predictions_dict = data_IO.observable_dict_from_matrix(emulator_predictions['central_value'],
-                                                                    observables)
+                                                                    observables,
+                                                                    observable_filter=emulation_config.observable_filter)
     # Plot
     columns = np.arange(posterior_samples.shape[0])
     plot_list = [emulator_predictions_dict['central_value']]


### PR DESCRIPTION
This allows for filtering all_observables again based on the overall emulation config

@jdmulligan This should fix the issue you mentioned in #15 . You just need to get the EmulationConfig and pass the corresponding observable_filter in that function