### PR TITLE
Speed up emulation.predict

### DIFF
--- a/config/rehlers.yaml
+++ b/config/rehlers.yaml
@@ -4,14 +4,14 @@
 
 output_dir: 'output/20230811'
 
-initialize_observables: True
+initialize_observables: False
 fit_emulators: False
-run_mcmc: False
+run_mcmc: True
 run_closure_tests: False
 
 plot:
   emulators: True
-  mcmc: False
+  mcmc: True
   qhat: False
   closure_tests: False
 

--- a/src/bayesian_inference/emulation.py
+++ b/src/bayesian_inference/emulation.py
@@ -307,7 +307,6 @@ class SortEmulationGroupObservables:
 ####################################################################################################################
 def predict(parameters: npt.NDArray[np.float64],
             emulation_config: EmulationConfig,
-            validation_set: bool = False,
             merge_predictions_over_groups: bool = True,
             emulation_group_results: dict[str, dict[str, Any]] | None = None) -> dict[str, npt.NDArray[np.float64]]:
     """
@@ -315,7 +314,6 @@ def predict(parameters: npt.NDArray[np.float64],
 
     :param ndarray[float] parameters: list of parameter values (e.g. [tau0, c1, c2, ...]), with shape (n_samples, n_parameters)
     :param EmulationConfig emulation_config: configuration object for the overall emulator (including all groups)
-    :param bool validation_set: whether to use the validation set (True) or the training set (False)
     :param bool merge_predictions_over_groups: whether to merge predictions over emulation groups (True)
                                                or return a dictionary of predictions for each group (False). Default: True
     :param dict emulator_group_results: dictionary containing results from each emulation group. If None, read from file.

--- a/src/bayesian_inference/plot_emulation.py
+++ b/src/bayesian_inference/plot_emulation.py
@@ -54,7 +54,6 @@ def plot(config):
         _plot_pca_reconstruction_error_by_feature(results, plot_dir, emulation_group_config)
 
         # Emulator plots
-        # TODO: validation_set doesn't do anything here yet because predict() doesn't use the validation_set argument!
         _plot_emulator_observables(results, emulation_group_config, plot_dir, validation_set=False)
         _plot_emulator_observables(results, emulation_group_config, plot_dir, validation_set=True)
 


### PR DESCRIPTION
Instead of re-deriving the mapping from the emulation group predictions to the order of the observables, we learn it once and then use the stored mapping, which should speed up the prediction substantially (if nothing else, it removes reading one file per prediction, replacing it with only doing it once). Note that I haven't done benchmarks, and there is still lots of room to speed it up.

It also cleans up a lot of noisy printouts in the process

